### PR TITLE
methods of export was changed.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { Warera } from "./classes/warera";
 import { IWareraInput } from "./interfaces/i-warera-input";
 
-function warera(date: IWareraInput | Date): Warera {
+export default function warera(date: IWareraInput | Date): Warera {
   if (date instanceof Date) {
     return Warera.createFromDate(date);
   } else if (date instanceof Object) {
@@ -10,5 +10,3 @@ function warera(date: IWareraInput | Date): Warera {
     throw new Error("Invalid argument.");
   }
 }
-
-export default warera;


### PR DESCRIPTION
I want to use this lib. on `js` project.
Before)
<img width="222" alt="スクリーンショット 2019-12-18 18 25 13" src="https://user-images.githubusercontent.com/16782937/71075120-e48e6580-21c6-11ea-8809-7a997cd4a9c7.png">
This PR)
<img width="445" alt="スクリーンショット 2019-12-18 18 26 00" src="https://user-images.githubusercontent.com/16782937/71075128-e6582900-21c6-11ea-97de-e05c33a6d967.png">


**Code change description**
I tried to change the way to export main function.

before:

```.ts
function warera() { ... }
export default warera;
```

It's OK on `ts`. But it occurred a small problem at importing into `.js`.

it should be:

```.ts
export default function warera(){ ... }
```

If you merge this PR, developers using js may be pleased morely.
